### PR TITLE
Added a check for Exception objects being passed

### DIFF
--- a/examples/trivial/main.py
+++ b/examples/trivial/main.py
@@ -37,6 +37,10 @@ def add_spans():
             child_span.set_tag('error', True)
             child_span.log_event('Uh Oh!', payload={'stacktrace': [tuple(f) for
                 f in traceback.extract_stack()]})
+            try:
+                raise ValueError("Invalid Coordinates", (1, 2, 3))
+            except BaseException as exc:
+                child_span.log_event('Uh Oh!', payload=exc)
             sleep_dot()
 
             # Play with the propagation APIs... this is not IPC and thus not
@@ -51,6 +55,7 @@ def add_spans():
                     remote_span.log_event('Remote!')
                     remote_span.set_tag('span_type', 'remote')
                     sleep_dot()
+
 
 def xray_tracer_from_args():
     """Initializes X-Ray from the commandline args.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[tool:pytest]
+python_files =
+    test_*.py
+    *_test.py

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="xray-python-opentracing",
-    version="0.0.1",
+    version="0.0.2",
     description="AWS X-Ray Python OpenTracing Implementation",
     long_description="",
     author="Jeremy Apthorp <nornagon@nornagon.net>",

--- a/xray_ot/connection.py
+++ b/xray_ot/connection.py
@@ -2,6 +2,8 @@
 import json
 from socket import AF_INET, SOCK_DGRAM, SocketType, socket
 
+from xray_ot.encoder import default_encoder
+
 
 class XRayConnection(object):
     """
@@ -14,7 +16,10 @@ class XRayConnection(object):
 
     @staticmethod
     def to_payload(msg) -> bytes:
-        return ('{"format": "json", "version": 1}\n' + json.dumps(msg)).encode("utf8")
+        return (
+            '{"format": "json", "version": 1}\n'
+            + json.dumps(msg, default=default_encoder)
+        ).encode("utf8")
 
     def report(self, msg) -> None:
         """Report to the daemon."""

--- a/xray_ot/encoder.py
+++ b/xray_ot/encoder.py
@@ -1,0 +1,20 @@
+import traceback
+from typing import Any, Type
+
+
+def default_encoder(o: Any) -> Any:
+    kind: Type[Any] = type(o)
+
+    if issubclass(kind, BaseException):
+        o: BaseException
+        tb = o.__traceback__
+        result = {
+            "exception": o.__class__.__name__,
+            "traceback": traceback.format_tb(tb),
+            "message": str(o),
+        }
+        return result
+
+    raise TypeError(
+        f"Object of type {o.__class__.__name__} is not JSON serializable"
+    )


### PR DESCRIPTION
```json
{
  "trace_id": "1-5f523fdc-f6aa28d9e6e2f125dd634e88",
  "id": "ba1c60dff4dc629b",
  "start_time": 1599225820.4943573,
  "end_time": 1599225820.5956147,
  "name": "trivial/child_request",
  "parent_id": "d54f49084466aeb8",
  "type": "subsegment",
  "annotations": {
    "_span_type": "child",
    "_error": true
  },
  "error": true,
  "metadata": {
    "logs": [
      {
        "timestamp": 1599225820.4947996,
        "fields": {
          "event": "Uh Oh!",
          "payload": {
            "exception": "ValueError",
            "traceback": [
              "  File \"examples/trivial/main.py\", line 41, in add_spans\n    raise ValueError(\"Invalid Coordinates\", (1, 2, 3))\n"
            ],
            "message": "('Invalid Coordinates', (1, 2, 3))"
          }
        }
      }
    ]
  }
}
```