### PR TITLE
No longer raise error on invalid objects

### DIFF
--- a/examples/trivial/main.py
+++ b/examples/trivial/main.py
@@ -20,6 +20,7 @@ def add_spans():
     """
     with opentracing.tracer.start_span(operation_name='trivial/initial_request') as parent_span:
         parent_span.set_tag('url', 'localhost')
+        parent_span.set_tag('invalid', int)
         sleep_dot()
         parent_span.log_event('All good here!', payload={'N': 42, 'pi': 3.14, 'abc': 'xyz'})
         parent_span.log_kv({'foo': 'bar', 'int': 42, 'float': 4.2, 'bool': True, 'obj': {'blargh': 'hmm', 'whee': 4324}})

--- a/xray_ot/encoder.py
+++ b/xray_ot/encoder.py
@@ -1,4 +1,5 @@
 import traceback
+import warnings
 from typing import Any, Type
 
 
@@ -15,6 +16,5 @@ def default_encoder(o: Any) -> Any:
         }
         return result
 
-    raise TypeError(
-        f"Object of type {o.__class__.__name__} is not JSON serializable"
-    )
+    warnings.warn("Unable to serialize object: %r" % o, UserWarning)
+    return repr(o)


### PR DESCRIPTION
Instead of raising when an application passes non JSON serializable objects, it will return the representation of it and dispatch a RuntimeWarning instead of raising (crashing).